### PR TITLE
Account payments GraphQL query

### DIFF
--- a/src/model/index.ts
+++ b/src/model/index.ts
@@ -12,6 +12,7 @@ export * from "./ledger";
 export * from "./ledger_header";
 export * from "./mutation_type";
 export * from "./native_trust_line_subscription_payload";
+export * from "./payment_operation";
 export * from "./transaction";
 export * from "./trust_line";
 export * from "./trust_line_subscription_payload";

--- a/src/model/payment_operation.ts
+++ b/src/model/payment_operation.ts
@@ -1,0 +1,30 @@
+import { publicKeyFromBuffer } from "../util/xdr/account";
+import { Asset } from "./";
+
+export interface IPaymentOperation {
+  source: string | null;
+  destination: string;
+  asset: Asset;
+  amount: string;
+}
+
+export class PaymentOperation implements IPaymentOperation {
+  public static buildFromXDR(xdr: any) {
+    const op = xdr.body().paymentOp();
+    const amount = op.amount().toString();
+    const destination = publicKeyFromBuffer(op.destination().value());
+    const asset = Asset.buildFromXDR(op.asset());
+
+    let source = null;
+
+    const account = xdr.sourceAccount();
+
+    if (account) {
+      source = publicKeyFromBuffer(account.value());
+    }
+
+    return new PaymentOperation(destination, asset, amount, source);
+  }
+
+  constructor(public destination: string, public asset: Asset, public amount: string, public source: string | null) {}
+}

--- a/src/schema/resolvers/index.ts
+++ b/src/schema/resolvers/index.ts
@@ -1,6 +1,7 @@
 import accountResolvers from "./account";
 import dataEntryResolvers from "./data_entry";
 import ledgerResolvers from "./ledger";
+import operationResolvers from "./operation";
 import signerResolvers from "./signer";
 import transactionResolvers from "./transaction";
 import trustLineResolvers from "./trust_line";
@@ -9,6 +10,7 @@ export default [
   accountResolvers,
   dataEntryResolvers,
   ledgerResolvers,
+  operationResolvers,
   signerResolvers,
   transactionResolvers,
   trustLineResolvers

--- a/src/schema/resolvers/operation.ts
+++ b/src/schema/resolvers/operation.ts
@@ -1,0 +1,13 @@
+import { Connection as DgraphConnection } from "../../storage/connection";
+import { AccountPaymentsQuery } from "../../storage/queries/account_payments";
+
+export default {
+  Query: {
+    accountPayments(root: any, args: any, ctx: any, info: any) {
+      const dc = new DgraphConnection();
+      const query = new AccountPaymentsQuery(dc, args.id, args.first, args.offset);
+
+      return query.call();
+    }
+  }
+};

--- a/src/schema/type_defs.ts
+++ b/src/schema/type_defs.ts
@@ -179,11 +179,19 @@ export default gql`
     timeBounds: TimeBounds
   }
 
+  type PaymentOperation {
+    destination: AccountID!
+    asset: Asset!
+    amount: String!
+    source: AccountID!
+  }
+
   type Query {
     account(id: AccountID!): Account
     accounts(id: [AccountID!]): [Account]
     accountsSignedBy(id: AccountID!, first: Int!): [Account!]
     accountTransactions(id: AccountID!, first: Int!, offset: Int): [Transaction]
+    accountPayments(id: AccountID!, first: Int!, offset: Int): [PaymentOperation]
     dataEntries(id: AccountID!): [DataEntry]
     signers(id: AccountID!): [Signer]
     trustLines(id: AccountID!): [TrustLine]

--- a/src/storage/queries/account_payments.ts
+++ b/src/storage/queries/account_payments.ts
@@ -1,0 +1,66 @@
+import dig from "object-dig";
+import { Asset, IPaymentOperation } from "../../model";
+import { Connection } from "../connection";
+import { IPaymentOperationData } from "../types";
+import { Query } from "./query";
+
+export type IAccountPaymentsQueryResult = IPaymentOperation[];
+
+export class AccountPaymentsQuery extends Query<IAccountPaymentsQueryResult> {
+  private id: string;
+  private first: number;
+  private offset: number;
+
+  constructor(connection: Connection, id: string, first: number, offset?: number) {
+    super(connection);
+    this.id = id;
+    this.first = first;
+    this.offset = offset || 0;
+  }
+
+  public async call(): Promise<IAccountPaymentsQueryResult> {
+    const r = await this.request();
+    const data = dig(r, "ops", 0, "operations");
+    return data.map(this.mapData);
+  }
+
+  protected async request(): Promise<any> {
+    return this.connection.query(
+      `
+        query accountOperations($id: string, $first: int, $offset: int) {
+          ops(func: eq(type, "account")) @filter(eq(id, $id)) {
+            operations(
+              first: $first,
+              offset: $offset,
+              orderdesc: order
+            ) @filter(eq(kind, "payment")) {
+              account.source { id }
+              account.destination { id }
+              asset {
+                code
+                native
+                issuer { id }
+              }
+              amount
+            }
+          }
+        }
+      `,
+      {
+        $id: this.id,
+        $first: this.first.toString(),
+        $offset: this.offset.toString()
+      }
+    );
+  }
+
+  private mapData(dgraphData: IPaymentOperationData): IPaymentOperation {
+    const asset = dgraphData.asset[0];
+    return {
+      destination: dgraphData["account.destination"][0].id,
+      source: dgraphData["account.source"][0].id,
+      amount: dgraphData.amount,
+      asset: new Asset(asset.native, asset.code, asset.issuer[0].id)
+    };
+  }
+}

--- a/src/storage/types.ts
+++ b/src/storage/types.ts
@@ -16,6 +16,19 @@ export interface ITransactionData {
   "time_bounds.max": number;
 }
 
+export interface IPaymentOperationData {
+  "account.source": IAccountData[];
+  "account.destination": IAccountData[];
+  amount: string;
+  asset: IAssetData[];
+}
+
+export interface IAssetData {
+  code: string;
+  issuer: IAccountData[];
+  native: boolean;
+}
+
 export interface IAccountData {
   id: string;
   // it's incomplete

--- a/src/storage/writers/asset.ts
+++ b/src/storage/writers/asset.ts
@@ -29,7 +29,9 @@ export class AssetWriter extends Writer {
       .for(this.current)
       .append("type", "asset")
       .append("native", this.asset.native)
-      .append("code", this.asset.code)
+      // we need to truncate null bytes to avoid breaking DGraph
+      // see https://github.com/dgraph-io/dgraph/issues/2662
+      .append("code", this.asset.code.replace(/\0/g, ""))
       .append("issuer", this.issuer);
 
     const created = await this.push("asset");

--- a/src/storage/writers/operation.ts
+++ b/src/storage/writers/operation.ts
@@ -1,4 +1,4 @@
-import { Asset, Transaction } from "../../model";
+import { Asset, PaymentOperation, Transaction } from "../../model";
 import { Connection } from "../connection";
 import { Writer } from "./writer";
 
@@ -115,16 +115,12 @@ export class OperationWriter extends Writer {
   }
 
   private async appendPaymentOp() {
-    const op = this.xdr.body().paymentOp();
+    const op = PaymentOperation.buildFromXDR(this.xdr);
 
-    const amount = op.amount().toString();
-    const destination = publicKeyFromBuffer(op.destination().value());
-    const asset = Asset.buildFromXDR(op.asset());
+    this.b.append(this.current, "amount", op.amount);
 
-    this.b.append(this.current, "amount", amount);
-
-    await this.appendAsset(this.current, "asset", asset, "operations");
-    await this.appendAccount(this.current, "account.destination", destination, "operations");
+    await this.appendAsset(this.current, "asset", op.asset, "operations");
+    await this.appendAccount(this.current, "account.destination", op.destination, "operations");
   }
 
   private async pathPaymentOp() {


### PR DESCRIPTION
Let me introduce `accountPayments` query 🙂

```
query {
  accountPayments(
    id: "GBPNAXTMWAGPBU4NLB7WU2SL346E4BVCUFJRJOM4AO7MNAFGJREUTOLS",
    first: 5,
    offset: 0
  ) {
    source
    destination
    amount
    asset {
      native
      code
      issuer
    }
  }
}
```

Example output:

```
{
  "data": {
    "accountPayments": [
      {
        "source": "GBPNAXTMWAGPBU4NLB7WU2SL346E4BVCUFJRJOM4AO7MNAFGJREUTOLS",
        "destination": "GCONNA5RNLVWD7T4AGP7P3XT5RJJYJGSJKCBT6KGGXHXEFHJR3EFNLTE",
        "amount": "400000000",
        "asset": {
          "native": false,
          "code": "KHL",
          "issuer": "GD7RDIVIVMWHDTKCEYA3B7CJ7TWKKDRJM6F74IBAT5YJWOQ6AIQT3SAW"
        }
      },
      {
        "source": "GBPNAXTMWAGPBU4NLB7WU2SL346E4BVCUFJRJOM4AO7MNAFGJREUTOLS",
        "destination": "GCONNA5RNLVWD7T4AGP7P3XT5RJJYJGSJKCBT6KGGXHXEFHJR3EFNLTE",
        "amount": "150000000",
        "asset": {
          "native": true,
          "code": "XLM",
          "issuer": "GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H"
        }
      },
...
```