### PR TITLE
Fix Docker build; lock Node to v10 LTS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,11 @@
 # ====================================================================================================
 
-FROM node:alpine AS build
+FROM node:10-alpine AS build
 
-ENV YARN_VERSION 1.10.1
 ENV NODE_ENV="production"
 
 # Packages
 RUN apk add --no-cache libc6-compat curl python g++ make postgresql-dev
-
-# Yarn
-RUN curl -fSLO --compressed "https://yarnpkg.com/downloads/$YARN_VERSION/yarn-v$YARN_VERSION.tar.gz" \
-    && tar -xzf yarn-v$YARN_VERSION.tar.gz -C /opt/ \
-    && ln -snf /opt/yarn-v$YARN_VERSION/bin/yarn /usr/local/bin/yarn \
-    && ln -snf /opt/yarn-v$YARN_VERSION/bin/yarnpkg /usr/local/bin/yarnpkg \
-    && rm yarn-v$YARN_VERSION.tar.gz
 
 WORKDIR /root
 
@@ -23,12 +15,12 @@ COPY tsconfig.json .
 COPY package.json .
 COPY yarn.lock .
 
-RUN yarn install --production=false --verbose
+RUN yarn install --production=false
 RUN yarn build
 
 # ====================================================================================================
 
-FROM node:alpine
+FROM node:10-alpine
 
 ENV NODE_ENV="production"
 ENV PORT 4000


### PR DESCRIPTION
- [x] Stay on LTS release of Node.js (should fix Google Cloud Build issue)
- [x] Official Node images now have yarn preinstalled, so remove custom yarn installation code