### PR TITLE
[WIP] Path payment operation results ingestion

### DIFF
--- a/src/dgraph_import.ts
+++ b/src/dgraph_import.ts
@@ -1,10 +1,10 @@
+import { setNetwork as setStellarNetwork } from "./util/stellar"; // for some weird reason it must be first
 import parseArgv from "minimist";
 import { Cursor, ICursorResult } from "./ingest/cursor";
 import { Connection } from "./storage/connection";
 import logger from "./util/logger";
 import "./util/memo";
 import { DGRAPH_URL } from "./util/secrets";
-import { setNetwork as setStellarNetwork } from "./util/stellar"; // for some weird reason it must be first
 
 if (!DGRAPH_URL) {
   logger.error("Please, provide DGRAPH_URL env variable");

--- a/src/storage/builders/account.ts
+++ b/src/storage/builders/account.ts
@@ -12,6 +12,10 @@ export class AccountBuilder extends Builder {
     return makeKey("account", id);
   }
 
+  public static fromXDR(xdr: any) {
+    return new AccountBuilder(publicKeyFromBuffer(xdr.value()));
+  }
+
   public readonly current: IBlank;
 
   constructor(private id: string) {

--- a/src/storage/builders/asset.ts
+++ b/src/storage/builders/asset.ts
@@ -13,6 +13,10 @@ export class AssetBuilder extends Builder {
     return makeKey("asset", asset.isNative().toString(), asset.getCode(), asset.getIssuer() || "");
   }
 
+  public static fromXDR(xdr: any) {
+    return new AssetBuilder(Asset.fromOperation(xdr));
+  }
+
   public readonly current: IBlank;
 
   constructor(private asset: Asset) {

--- a/src/storage/builders/operation.ts
+++ b/src/storage/builders/operation.ts
@@ -69,9 +69,9 @@ export class OperationBuilder extends Builder {
       case t.createAccount():
         return new CreateAccountOpBuilder(this.current, this.xdr.body().createAccountOp(), this.resultXDR);
       case t.payment():
-        return new PaymentOpBuilder(this.current, this.xdr.body().paymentOp());
+        return new PaymentOpBuilder(this.current, this.xdr.body().paymentOp(), this.resultXDR);
       case t.pathPayment():
-        return new PathPaymentOpBuilder(this.current, this.xdr.body().pathPaymentOp());
+        return new PathPaymentOpBuilder(this.current, this.xdr.body().pathPaymentOp(), this.resultXDR);
       case t.manageOffer():
         return new ManageOfferOpBuilder(this.current, this.xdr.body().manageOfferOp());
       case t.setOption():

--- a/src/storage/builders/operation.ts
+++ b/src/storage/builders/operation.ts
@@ -71,7 +71,11 @@ export class OperationBuilder extends Builder {
       case t.payment():
         return new PaymentOpBuilder(this.current, this.xdr.body().paymentOp(), this.resultXDR);
       case t.pathPayment():
-        return new PathPaymentOpBuilder(this.current, this.xdr.body().pathPaymentOp(), this.resultXDR);
+        return new PathPaymentOpBuilder(this.current, this.xdr.body().pathPaymentOp(), this.resultXDR, [
+          this.tx.ledgerSeq,
+          this.index,
+          this.n
+        ]);
       case t.manageOffer():
         return new ManageOfferOpBuilder(this.current, this.xdr.body().manageOfferOp());
       case t.setOption():

--- a/src/storage/builders/operations/path_payment_op.ts
+++ b/src/storage/builders/operations/path_payment_op.ts
@@ -1,10 +1,18 @@
-import { NQuads } from "../../nquads";
+import { IBlank, NQuads } from "../../nquads";
 import { AccountBuilder } from "../account";
 import { AssetBuilder } from "../asset";
 import { PathPaymentResultBuilder } from "../path_payment_result";
 import { SpecificOperationBuilder } from "../specific_operation";
 
 export class PathPaymentOpBuilder extends SpecificOperationBuilder {
+  private baseKey: any[];
+
+  constructor(public readonly current: IBlank, protected xdr: any, protected resultXDR: any, baseKey: any[]) {
+    super(current, xdr, resultXDR);
+
+    this.baseKey = baseKey;
+  }
+
   public build(): NQuads {
     super.build();
     this.pushValue("send_max", this.xdr.sendMax().toString());
@@ -21,7 +29,7 @@ export class PathPaymentOpBuilder extends SpecificOperationBuilder {
   }
 
   protected pushResult() {
-    const resultBuilder = new PathPaymentResultBuilder(this.current.value, this.trXDR.pathPaymentResult());
+    const resultBuilder = new PathPaymentResultBuilder(this.baseKey, this.trXDR.pathPaymentResult());
 
     this.pushBuilder(resultBuilder, "result");
   }

--- a/src/storage/builders/operations/payment_op.ts
+++ b/src/storage/builders/operations/payment_op.ts
@@ -1,18 +1,15 @@
 import { Asset } from "stellar-sdk";
 
 import { publicKeyFromBuffer } from "../../../util/xdr/account";
-import { IBlank, NQuads } from "../../nquads";
+import { NQuads } from "../../nquads";
 
 import { AccountBuilder } from "../account";
 import { AssetBuilder } from "../asset";
-import { Builder } from "../builder";
+import { SpecificOperationBuilder } from "../specific_operation";
 
-export class PaymentOpBuilder extends Builder {
-  constructor(public readonly current: IBlank, private xdr: any) {
-    super();
-  }
-
+export class PaymentOpBuilder extends SpecificOperationBuilder {
   public build(): NQuads {
+    super.build();
     const asset = Asset.fromOperation(this.xdr.asset());
     const amount = this.xdr.amount().toString();
     const destination = publicKeyFromBuffer(this.xdr.destination().value());
@@ -22,5 +19,10 @@ export class PaymentOpBuilder extends Builder {
     this.pushBuilder(new AssetBuilder(asset), "asset", "operations");
 
     return this.nquads;
+  }
+
+  protected pushResult() {
+    const code = this.trXDR.paymentResult().switch().value;
+    this.pushValue("payment_result_code", code);
   }
 }

--- a/src/storage/builders/path_payment_result.ts
+++ b/src/storage/builders/path_payment_result.ts
@@ -5,16 +5,20 @@ import { AssetBuilder } from "./asset_builder";
 import { Builder } from "./builder";
 
 export class PathPaymentResultBuilder extends Builder {
-  public static key(id: string) {
-    return makeKey("path_payment_result", id);
+  public static key(args: any[]): string {
+    return makeKey("path_payment_result", ...args);
+  }
+
+  public static keyNQuad(args: any[]): IBlank {
+    return NQuad.blank(PathPaymentResultBuilder.key(args));
   }
 
   public current: IBlank;
   private success: any;
 
-  constructor(operationKey: string, private xdr: any) {
+  constructor(baseKey: any[], private xdr: any) {
     super();
-    this.current = NQuad.blank(PathPaymentResultBuilder.key(operationKey));
+    this.current = PathPaymentResultBuilder.keyNQuad(baseKey);
     this.success = xdr.success();
   }
 

--- a/src/storage/builders/path_payment_result.ts
+++ b/src/storage/builders/path_payment_result.ts
@@ -1,0 +1,76 @@
+import { makeKey } from "../../util/crypto";
+import { IBlank, NQuad, NQuads } from "../nquads";
+import { AccountBuilder } from "./account";
+import { AssetBuilder } from "./asset_builder";
+import { Builder } from "./builder";
+
+export class PathPaymentResultBuilder extends Builder {
+  public static key(id: string) {
+    return makeKey("path_payment_result", id);
+  }
+
+  public current: IBlank;
+  private success: any;
+
+  constructor(operationKey: string, private xdr: any) {
+    super();
+    this.current = NQuad.blank(PathPaymentResultBuilder.key(operationKey));
+    this.success = xdr.success();
+  }
+
+  public build(): NQuads {
+    const code = this.xdr.switch().value;
+    this.pushValue("path_payment_result_code", code);
+
+    if (this.success === undefined) {
+      // FIXME handle failure
+      return [];
+    }
+
+    this.pushLast();
+    this.pushOffers();
+
+    return this.nquads;
+  }
+
+  private pushLast() {
+    const lastNQuad = NQuad.blank(`${this.current.value}_last`);
+    const last = this.success.last();
+
+    this.nquads.push(new NQuad(this.current, "last", lastNQuad));
+
+    const destinationAccountBuilder = AccountBuilder.fromXDR(last.destination());
+    const lastAssetBuilder = AssetBuilder.fromXDR(last.asset());
+
+    this.pushBuilder(destinationAccountBuilder);
+    this.pushBuilder(lastAssetBuilder);
+
+    this.nquads.push(new NQuad(lastNQuad, "account.destination", destinationAccountBuilder.current));
+    this.nquads.push(new NQuad(lastNQuad, "asset", lastAssetBuilder.current));
+  }
+
+  private pushOffers() {
+    this.success.offers().forEach((offer: any, index: number) => {
+      const offerNQuad = NQuad.blank(`${this.current.value}_result_offer_${index}`);
+
+      const sellerBuilder = AccountBuilder.fromXDR(offer.sellerId());
+      this.pushBuilder(sellerBuilder);
+      this.nquads.push(new NQuad(offerNQuad, "seller", sellerBuilder.current));
+
+      const assetSoldBuilder = AssetBuilder.fromXDR(offer.assetSold());
+      const assetBoughtBuilder = AssetBuilder.fromXDR(offer.assetBought());
+
+      this.pushBuilder(assetSoldBuilder);
+      this.pushBuilder(assetBoughtBuilder);
+
+      this.nquads.push(new NQuad(offerNQuad, "asset.sold", assetSoldBuilder.current));
+      this.nquads.push(new NQuad(offerNQuad, "asset.bought", assetBoughtBuilder.current));
+
+      this.nquads.push(new NQuad(offerNQuad, "offer_id", NQuad.value(offer.offerId().toString())));
+      this.nquads.push(new NQuad(offerNQuad, "amount_sold", NQuad.value(offer.amountSold().toString())));
+      this.nquads.push(new NQuad(offerNQuad, "amount_bought", NQuad.value(offer.amountBought().toString())));
+
+      this.nquads.push(new NQuad(this.current, "offers", offerNQuad));
+    });
+  }
+}


### PR DESCRIPTION
Resolve #85 

At the moment I don't know, how to test not successful path payment. How it can be unsuccessful in ledger at all? 🤔 

Also refactoring can be good, there is a lot of code in offers ingestion.

Here is the structure in dgraph:

```
{
  "result": [
    {
      "last": [
        {
          "asset": [
            {
              "code": "LED",
              "uid": "0xc5f"
            }
          ],
          "account.destination": [
            {
              "id": "GDUT74IS7JGLJ7KQWGJJWTND7TJC4FATVBFM7LGOORID2GNN7KU7LXMK",
              "uid": "0xc3a"
            }
          ],
          "uid": "0xc7d"
        }
      ],
      "offers": [
        {
          "offer_id": "1",
          "amount_sold": "100000000",
          "amount_bought": "100000000",
          "seller": [
            {
              "id": "GBM5VGUETXESCVCDTKJM4P6KLZLQLV7LBZNX6UGAOYFH6P6GRI6GI6K7",
              "uid": "0xc35"
            }
          ],
          "asset.bought": [
            {
              "code": "XLM",
              "uid": "0xc40"
            }
          ],
          "asset.sold": [
            {
              "code": "KHL",
              "issuer": [
                {
                  "id": "GCB35W2WLDQYTPSIGPMBCCZDMO7VGREOX6L4NMEU4DJXWSFQDHNVDLBU",
                  "uid": "0xc37"
                }
              ],
              "uid": "0xc5e"
            }
          ],
          "uid": "0xc78"
        },
        {
          "offer_id": "2",
          "amount_sold": "100000000",
          "amount_bought": "100000000",
          "seller": [
            {
              "id": "GBM5VGUETXESCVCDTKJM4P6KLZLQLV7LBZNX6UGAOYFH6P6GRI6GI6K7",
              "uid": "0xc35"
            }
          ],
          "asset.bought": [
            {
              "code": "KHL",
              "issuer": [
                {
                  "id": "GCB35W2WLDQYTPSIGPMBCCZDMO7VGREOX6L4NMEU4DJXWSFQDHNVDLBU",
                  "uid": "0xc37"
                }
              ],
              "uid": "0xc5e"
            }
          ],
          "asset.sold": [
            {
              "code": "LED",
              "issuer": [
                {
                  "id": "GCTSMUD4YSRRXEBBGDHUB3H5KWH3DSMFUWCHCPOQ3CVBKNDLDMNFXSRW",
                  "uid": "0xc2e"
                }
              ],
              "uid": "0xc5f"
            }
          ],
          "uid": "0xc7e"
        }
      ],
      "uid": "0xc77"
    }
  ],
  "uid": "0xc7c"
}
```